### PR TITLE
bump to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2022-05-23
+- use unix `diff` for commit log comparison.
+- explicit mechanism to disable logging in `utils.sys_command`
+- print the total number of failed tests in log
+
 ## [1.1.1] - 2022-03-19
 - fix return code out and err in sys\_command and run functions in utils
 

--- a/river_core/__init__.py
+++ b/river_core/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors"""
 __email__ = 'info@incoresemi.com'
-__version__ = '1.1.1'
+__version__ = '1.2.0'

--- a/river_core/requirements.txt
+++ b/river_core/requirements.txt
@@ -1,7 +1,6 @@
 pip
 wheel==0.33.6
 coverage==4.5.4
-Sphinx==3.0.4
 click>=7.0
 ruamel.yaml>=0.16.0
 pytest

--- a/river_core/rivercore.py
+++ b/river_core/rivercore.py
@@ -242,6 +242,11 @@ def rivercore_clean(config_file, verbosity):
 
     config = configparser.ConfigParser()
     config.read(config_file)
+    # check for ISA string in upper case
+    _isa = config['river_core']['isa']
+    logger.info(f'ISA:  {_isa}')
+    utils.check_isa(_isa)
+
     output_dir = config['river_core']['work_dir']
     logger.level(verbosity)
     logger.info('****** RiVer Core {0} *******'.format(__version__))
@@ -282,7 +287,11 @@ def rivercore_generate(config_file, verbosity):
     logger.level(verbosity)
     config = configparser.ConfigParser()
     config.read(config_file)
-    logger.debug('Read file from {0}'.format(config_file))
+    # check for ISA string in upper case
+    _isa = config['river_core']['isa']
+    logger.info(f'ISA:  {_isa}')
+    utils.check_isa(_isa)
+    logger.debug('Read file from {0}'.format(os.path.abspath(config_file)))
 
     output_dir = config['river_core']['work_dir']
 
@@ -419,7 +428,11 @@ def rivercore_compile(config_file, test_list, coverage, verbosity, dut_flags,
     logger.level(verbosity)
     config = configparser.ConfigParser()
     config.read(config_file)
-    logger.debug('Read file from {0}'.format(config_file))
+    # check for ISA string in upper case
+    _isa = config['river_core']['isa']
+    logger.info(f'ISA:  {_isa}')
+    utils.check_isa(_isa)
+    logger.debug('Read file from {0}'.format(os.path.abspath(config_file)))
 
     logger.info('****** Compilation Mode ******')
 
@@ -741,7 +754,11 @@ def rivercore_merge(verbosity, db_folders, output, config_file):
     logger.level(verbosity)
     config = configparser.ConfigParser()
     config.read(config_file)
-    logger.debug('Read file from {0}'.format(config_file))
+    # check for ISA string in upper case
+    _isa = config['river_core']['isa']
+    logger.info(f'ISA:  {_isa}')
+    utils.check_isa(_isa)
+    logger.debug('Read file from {0}'.format(os.path.abspath(config_file)))
     target = config['river_core']['target']
 
     logger.info('****** Merge Mode ******')

--- a/river_core/rivercore.py
+++ b/river_core/rivercore.py
@@ -634,9 +634,11 @@ def rivercore_compile(config_file, test_list, coverage, verbosity, dut_flags,
             for test, attr in test_dict.items():
                 if attr['result'] == 'Failed' or 'Unavailable' in attr['result']:
                     failed_dict[test] = attr
-            failed_dict_file = output_dir+'/failed_list.yaml'
-            logger.info(f'Saving failed list of tests in {failed_dict_file}')
-            utils.save_yaml(failed_dict, failed_dict_file)
+            if len(failed_dict) != 0:
+                logger.error(f'Total Tests that Failed :{len(failed_dict)}')
+                failed_dict_file = output_dir+'/failed_list.yaml'
+                logger.error(f'Saving failed list of tests in {failed_dict_file}')
+                utils.save_yaml(failed_dict, failed_dict_file)
 
 
             # Start checking things after running the commands

--- a/river_core/utils.py
+++ b/river_core/utils.py
@@ -115,6 +115,20 @@ def load_yaml(input_yaml):
         raise SystemExit
 
 
+def check_isa(isa):
+    if 'Z' in isa:
+        extensions = isa.split('Z')
+        if extensions[0].upper() != extensions[0]:
+            raise Exception('ISA Error: Ratified extensions should be in '
+                            'uppercase')
+    elif 'z' in isa:
+        raise Exception('ISA Error: unratified extension with lowercase Z')
+    else:
+        if isa.upper() != isa:
+            raise Exception('ISA Error: Ratified extensions should be in '
+                            'uppercase')
+
+
 def sys_command(command, timeout=240):
     '''
         Wrapper function to run shell commands with a timeout.
@@ -157,6 +171,7 @@ def sys_command(command, timeout=240):
             return 1, "GuruMeditation", "TimeoutExpired"
         rout = ''
         rerr = ''
+        cwd = os.getcwd()
         try:
             fmt = sys.stdout.encoding if sys.stdout.encoding is not None else 'utf-8'
             rout = out.decode(fmt)
@@ -185,7 +200,7 @@ def sys_command(command, timeout=240):
             rerr = "Unable to decode STDERR for launched subprocess. Output written to:"+ cwd+"/stderr.log"
             with open(cwd+"/stderr.log","wb") as f:
                 f.write(out)
-    return (process.returncode, rout, rerr)
+    return process.returncode, rout, rerr
 
 
 def sys_command_file(command, filename, timeout=500):

--- a/river_core/utils.py
+++ b/river_core/utils.py
@@ -33,12 +33,11 @@ def compare_signature(file1, file2):
         logger.error('Signature file : ' + file1 + ' does not exist')
         raise SystemExit(1)
     cmd = f'diff -iw {file1} {file2}'
-    errcode, rout, rerr = sys_command(cmd)
+    errcode, rout, rerr = sys_command(cmd, logging=False)
     if errcode != 0:
         status = 'Failed'
     else:
         status = 'Passed'
-    res = rout
 
 #    file1_lines = open(file1, "r").readlines()
 #    file2_lines = open(file2, "r").readlines()
@@ -71,7 +70,7 @@ def compare_signature(file1, file2):
 #                include = False
 #                prev = rline
 ##        res = error_report
-    return status, res
+    return status, rout
 
 def str_2_bool(string):
     """
@@ -138,7 +137,7 @@ def check_isa(isa):
                             'uppercase')
 
 
-def sys_command(command, timeout=240):
+def sys_command(command, timeout=240, logging=True):
     '''
         Wrapper function to run shell commands with a timeout.
         Uses :py:mod:`subprocess`, :py:mod:`shlex`, :py:mod:`os`
@@ -185,12 +184,13 @@ def sys_command(command, timeout=240):
             fmt = sys.stdout.encoding if sys.stdout.encoding is not None else 'utf-8'
             rout = out.decode(fmt)
             if out:
-                if process.returncode != 0:
+                if process.returncode != 0 and logging:
                     logger.error(out.decode(fmt))
-                else:
+                elif logging:
                     logger.debug(out.decode(fmt))
         except UnicodeError:
-            logger.warning("Unable to decode STDOUT for launched subprocess. Output written to:"+
+            if logging:
+                logger.warning("Unable to decode STDOUT for launched subprocess. Output written to:"+
                     cwd+"/stdout.log")
             rout = "Unable to decode STDOUT for launched subprocess. Output written to:"+ cwd+"/stdout.log"
             with open(cwd+"/stdout.log","wb") as f:
@@ -199,12 +199,13 @@ def sys_command(command, timeout=240):
             fmt = sys.stderr.encoding if sys.stdout.encoding is not None else 'utf-8'
             rerr = err.decode(fmt)
             if err:
-                if process.returncode != 0:
+                if process.returncode != 0 and logging:
                     logger.error(err.decode(fmt))
-                else:
+                elif logging:
                     logger.debug(err.decode(fmt))
         except UnicodeError:
-            logger.warning("Unable to decode STDERR for launched subprocess. Output written to:"+
+            if logging:
+                logger.warning("Unable to decode STDERR for launched subprocess. Output written to:"+
                     cwd+"/stderr.log")
             rerr = "Unable to decode STDERR for launched subprocess. Output written to:"+ cwd+"/stderr.log"
             with open(cwd+"/stderr.log","wb") as f:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.2.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     tests_require=test_requirements,
     url=
     'https://github.com/incoresemi/river_core',
-    version='1.1.1',
+    version='1.2.0',
     zip_safe=False,
 )


### PR DESCRIPTION
- use unix `diff` for commit log comparison.
- explicit mechanism to disable logging in `utils.sys_command`
- print the total number of failed tests in log
