### PR TITLE
Fixed diff operation for missing line scenario

### DIFF
--- a/river_core/__init__.py
+++ b/river_core/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors"""
 __email__ = 'info@incoresemi.com'
-__version__ = '1.9.0'
+__version__ = '1.9.1'

--- a/river_core/utils.py
+++ b/river_core/utils.py
@@ -67,9 +67,6 @@ def compare_dumps(file1, file2, start_hex=''):
 
         rout += '\nMismatch infos:'
 
-        # initial status
-        status = 'Passed'
-
         # get lines that start with < or >
         mismatch_str_lst = list(filter(lambda x: x[0] in ['<', '>'], rout.split('\n')))
 
@@ -80,18 +77,25 @@ def compare_dumps(file1, file2, start_hex=''):
             file1_str = mismatch_str_lst[i]
             if file1_str[0] != '<':
                 continue
+
+            try:
+                file1_dat = dump_regex.findall(file1_str)[0]
+            except IndexError:
+                status = 'Failed'
+                break
             
+            flag_found_corr_file2 = False
             for j in range(start_val + 1, len(mismatch_str_lst)):
                 
-                file2_str = mismatch_str_lst[j] 
+                file2_str = mismatch_str_lst[j]
                 if file2_str[0] != '>':
                     continue
                 else:
+                    flag_found_corr_file2 = True
                     start_val = j
 
                 # get regex strings
                 try:
-                    file1_dat = dump_regex.findall(file1_str)[0]
                     file2_dat = dump_regex.findall(file2_str)[0]
                 except IndexError:
                     status = 'Failed'
@@ -122,6 +126,10 @@ def compare_dumps(file1, file2, start_hex=''):
                         rout = rout + f'\nSM: at PC: {file1_dat[2]}'
                         status = 'Failed'
                 break
+
+            if not flag_found_corr_file2:
+                status = 'Failed'
+                rout = rout + f'\nBM: {file1} at PC: {file1_dat[2]} and missing in {file2}'
     else:
         status = 'Passed'
     

--- a/river_core/utils.py
+++ b/river_core/utils.py
@@ -67,8 +67,6 @@ def compare_dumps(file1, file2, start_hex=''):
 
         rout += '\nMismatch infos:'
 
-        status = ''
-
         # get lines that start with < or >
         mismatch_str_lst = list(filter(lambda x: x[0] in ['<', '>'], rout.split('\n')))
 

--- a/river_core/utils.py
+++ b/river_core/utils.py
@@ -131,11 +131,13 @@ def compare_dumps(file1, file2, start_hex=''):
                         rout = rout + f'\nSM: at PC: {file1_dat[2]}'
                         status = 'Failed'
                 break
-
+            
+            # if corresponding diff is not found, report fail
             if not flag_found_corr_file2:
                 status = 'Failed'
                 rout = rout + f'\nBM: {file1} at PC: {file1_dat[2]} and missing in {file2}'
         
+        # if corresponding diff is not found, report fail
         if not flag_found_corr_file1:
             status = 'Failed'
             rout = rout + f'\nBM: Mising entry in {file1} '

--- a/river_core/utils.py
+++ b/river_core/utils.py
@@ -67,16 +67,21 @@ def compare_dumps(file1, file2, start_hex=''):
 
         rout += '\nMismatch infos:'
 
+        status = ''
+
         # get lines that start with < or >
         mismatch_str_lst = list(filter(lambda x: x[0] in ['<', '>'], rout.split('\n')))
 
         # for each mismatched strings
         start_val = -1
+        flag_found_corr_file1 = False
         for i in range(len(mismatch_str_lst)):
             
             file1_str = mismatch_str_lst[i]
             if file1_str[0] != '<':
                 continue
+            else:
+                flag_found_corr_file1 = True
 
             try:
                 file1_dat = dump_regex.findall(file1_str)[0]
@@ -130,6 +135,10 @@ def compare_dumps(file1, file2, start_hex=''):
             if not flag_found_corr_file2:
                 status = 'Failed'
                 rout = rout + f'\nBM: {file1} at PC: {file1_dat[2]} and missing in {file2}'
+        
+        if not flag_found_corr_file1:
+            status = 'Failed'
+            rout = rout + f'\nBM: Mising entry in {file1} '
     else:
         status = 'Passed'
     

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.0
+current_version = 1.9.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     tests_require=test_requirements,
     url=
     'https://github.com/incoresemi/river_core',
-    version='1.9.0',
+    version='1.9.1',
     zip_safe=False,
 )


### PR DESCRIPTION
`compare_dumps` erroneously marked dumps with missing lines wrt each other as 'Passed'. This is taken care of. The initial status of test is set to be invalid for catching more errors similar to this in future.