### PR TITLE
fix: generator.json searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.7] - 2025-06-13
+- fixed generator.json searching functionality
+
 ## [1.9.6] - 2025-05-14
 - bumped python version for CI job
 

--- a/river_core/__init__.py
+++ b/river_core/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors"""
 __email__ = 'info@incoresemi.com'
-__version__ = '1.9.6'
+__version__ = '1.9.7'

--- a/river_core/rivercore.py
+++ b/river_core/rivercore.py
@@ -700,18 +700,24 @@ def rivercore_compile(config_file, test_list, coverage, verbosity, dut_flags,
             try:
                 logger.info(
                     "Checking for a generator json to create final report")
-                json_files = glob.glob(output_dir + '/.json/{0}*.json'.format(
-                    config['river_core']['generator']))
+                generators = [g.strip() for g in config['river_core']['generator'].split(',')]
+                json_files = []
+                for gen in generators:
+                    matched_files = glob.glob(os.path.join(
+                        output_dir, '.json', f'{gen}_*.json'))
+                    json_files.extend(matched_files)
                 logger.debug(
                     "Detected generated JSON Files: {0}".format(json_files))
-
                 # Can only get one file back
-                gen_json_file = max(json_files, key=os.path.getctime)
-                json_file = open(gen_json_file, 'r')
-                target_json_list = json_file.readlines()
-                json_file.close()
-                for line in target_json_list:
-                    gen_json_data.append(json.loads(line))
+                if json_files:
+                    gen_json_file = max(json_files, key=os.path.getctime) # Get the most recent one
+                    with open(gen_json_file, 'r') as json_file:
+                        for line in json_file:
+                            gen_json_data.append(json.loads(line))
+                else:
+                    logger.warning(
+                        "No JSON files matched the specified generators")
+                    gen_json_file = []
 
             except:
                 logger.warning("Couldn't find a generator JSON file")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.6
+current_version = 1.9.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     tests_require=test_requirements,
     url=
     'https://github.com/incoresemi/river_core',
-    version='1.9.6',
+    version='1.9.7',
     zip_safe=False,
 )


### PR DESCRIPTION
**Fixes #33**

`generator.json` searching did not work when more than 1 generator was enabled, as it was searching for the entire string instead of specific test-generator names.
